### PR TITLE
Uses `install_requires` in setup.py, fixes #27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='coreypetty',
     author_email='corey.a.petty@gmail.com',
     description='Python Bindings to Etherscan.io API',
-    requires=[
+    install_requires=[
         'requests==2.18.4',
     ],
 )


### PR DESCRIPTION
Proof that it's working.

Trying to install the current version:
```
$ pip install https://github.com/corpetty/py-etherscan-api/archive/f45a313.zip#egg=py-etherscan-api
Collecting py-etherscan-api from https://github.com/corpetty/py-etherscan-api/archive/f45a313.zip#egg=py-etherscan-api
  Downloading https://github.com/corpetty/py-etherscan-api/archive/f45a313.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-93q1659z/py-etherscan-api/setup.py", line 13, in <module>
        'requests==2.18.4',
      File "/usr/lib/python3.6/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/andre/workspace/py-etherscan-api/venv/lib/python3.6/site-packages/setuptools/dist.py", line 370, in __init__
        k: v for k, v in attrs.items()
      File "/usr/lib/python3.6/distutils/dist.py", line 253, in __init__
        getattr(self.metadata, "set_" + key)(val)
      File "/usr/lib/python3.6/distutils/dist.py", line 1207, in set_requires
        distutils.versionpredicate.VersionPredicate(v)
      File "/usr/lib/python3.6/distutils/versionpredicate.py", line 114, in __init__
        raise ValueError("expected parenthesized list: %r" % paren)
    ValueError: expected parenthesized list: '==2.18.4'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-93q1659z/py-etherscan-api/
```
Now trying from my fork:
```
$ pip install https://github.com/AndreMiras/py-etherscan-api/archive/feature/setup_install_requires.zip#egg=py-etherscan-api
Collecting py-etherscan-api from https://github.com/AndreMiras/py-etherscan-api/archive/feature/setup_install_requires.zip#egg=py-etherscan-api
  Downloading https://github.com/AndreMiras/py-etherscan-api/archive/feature/setup_install_requires.zip
     | 30kB 272kB/s
Requirement already satisfied: requests==2.18.4 in ./venv/lib/python3.6/site-packages (from py-etherscan-api) (2.18.4)
Requirement already satisfied: idna<2.7,>=2.5 in ./venv/lib/python3.6/site-packages (from requests==2.18.4->py-etherscan-api) (2.6)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in ./venv/lib/python3.6/site-packages (from requests==2.18.4->py-etherscan-api) (3.0.4)
Requirement already satisfied: urllib3<1.23,>=1.21.1 in ./venv/lib/python3.6/site-packages (from requests==2.18.4->py-etherscan-api) (1.22)
Requirement already satisfied: certifi>=2017.4.17 in ./venv/lib/python3.6/site-packages (from requests==2.18.4->py-etherscan-api) (2018.4.16)
Building wheels for collected packages: py-etherscan-api
  Running setup.py bdist_wheel for py-etherscan-api ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-3kbji2eo/wheels/51/89/6b/4f3e09a0eb8d3b65639cb2f38aa6ea2be78903883defd52701
Successfully built py-etherscan-api
Installing collected packages: py-etherscan-api
Successfully installed py-etherscan-api-0.7.0
```