### PR TITLE
Introduces CI with Travis and tox, fixes #20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install: pip install tox-travis
+script: tox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # py-etherscan-api module
+
+[![Build Status](https://secure.travis-ci.org/corpetty/py-etherscan-api.png?branch=master)](http://travis-ci.org/corpetty/py-etherscan-api)
+
 EtherScan.io API python bindings
 
 ## Description

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py3
+
+[testenv]
+deps =
+    pytest
+    -r{toxinidir}/pip-requirements.txt
+commands =
+    python -m unittest discover --start-directory=tests/


### PR DESCRIPTION
Introduces Continuous Integration testing with Travis and tox.
Checks few unit tests for Python 2.7 & 3.6 and verifies the module
installs properly.
Repository needs to be enabled in Travis with one click in:
https://travis-ci.org/corpetty/py-etherscan-api

Build is green :heavy_check_mark: in my fork, see https://travis-ci.org/AndreMiras/py-etherscan-api/builds/384099730
Think about enabling Travis before the merge (just one click if already paired with your GitHub account) so it starts building on merge.