### PR TITLE
Updates requests dependency (security)

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,2 +1,2 @@
-requests==2.18.4
+requests>=2.20.0
 typing==3.6.4

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     author_email='corey.a.petty@gmail.com',
     description='Python Bindings to Etherscan.io API',
     install_requires=[
-        'requests==2.18.4',
+        'requests>=2.20.0',
     ],
 )


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-18074
Also uses greater than, rather than pinning exact version.